### PR TITLE
Support for python < 3.8

### DIFF
--- a/pyloggor/pyloggor.py
+++ b/pyloggor/pyloggor.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
-from typing import Literal, Optional, TextIO, Union
+from typing import Optional, TextIO, Union
+from typing_extensions import Literal
 import json
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='https://www.github.com/PrivatePandaCO/pyloggor',
     license='MIT',
     packages=['pyloggor'],
-    install_requires=['rich'],
+    install_requires=['rich', 'typing-extensions'],
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     project_urls={


### PR DESCRIPTION
Literal was added to the typing module in python version 3.8, this pull request ensures that pyloggor uses typing-extensions for Literal instead of typing to support lower python versions